### PR TITLE
feat: add root certificate location for https registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY hack/entrypoint.sh /entrypoint.sh
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/manager"]

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,3 +9,7 @@ images:
 - name: open-component-model/replication-controller
   newName: ghcr.io/open-component-model/replication-controller
   newTag: latest
+
+# Uncomment to enable HTTPS for the registry
+#patches:
+#- path: ./patches/add_root_certificates.yaml

--- a/config/manager/patches/add_root_certificates.yaml
+++ b/config/manager/patches/add_root_certificates.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: replication-controller
+  labels:
+    control-plane: controller
+spec:
+  selector:
+    matchLabels:
+      app: replication-controller
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: open-component-model/replication-controller
+          env:
+            - name: REGISTRY_ROOT_CERTIFICATE # optionally define to override default location
+              value: /certs/ca.pem
+          volumeMounts:
+            - mountPath: "/certs"
+              name: "certificates"
+      volumes:
+        - name: "certificates"
+          secret:
+            secretName: "registry-certs"
+            items:
+              - key: "ca.pem"
+                path: "ca.pem"

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+rootCA=${REGISTRY_ROOT_CERTIFICATE:-/certs/ca.pem}
+
+if [ ! -e "${rootCA}" ]; then
+  echo "warning... root certificate at location ${rootCA} not found."
+
+  exec "$@"
+fi
+
+echo "updating root certificate with provided certificate..."
+tee -a /etc/ssl/certs/ca-certificates.crt < "${rootCA}"
+
+echo "done."
+
+exec "$@"

--- a/tilt-settings.yaml
+++ b/tilt-settings.yaml
@@ -1,0 +1,3 @@
+root_certificate_secret:
+  enable: true
+  name: "registry-certs"

--- a/tilt.dockerfile
+++ b/tilt.dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 WORKDIR /
 COPY ./bin/manager /manager
+COPY ./hack/entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/manager"]


### PR DESCRIPTION
This is independent from the changes in https://github.com/open-component-model/ocm-controller/pull/223 as it will just continue as is if the certificate is not there. This is purely a container related change.